### PR TITLE
Changes to support "turbine" endcap ECal

### DIFF
--- a/RecCalorimeter/src/components/CreateCaloCells.cpp
+++ b/RecCalorimeter/src/components/CreateCaloCells.cpp
@@ -67,7 +67,12 @@ StatusCode CreateCaloCells::initialize() {
   }
 
   // Copy over the CellIDEncoding string from the input collection to the output collection
-  m_cellsCellIDEncoding.put(m_hitsCellIDEncoding.get());
+  auto hitsEncoding = m_hitsCellIDEncoding.get_optional();
+  if (!hitsEncoding.has_value()) {
+    error () << "Missing cellID encoding for input collection" << endmsg;
+    return StatusCode::FAILURE;
+  }
+  m_cellsCellIDEncoding.put(hitsEncoding.value());
 
   return StatusCode::SUCCESS;
 }

--- a/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.cpp
@@ -67,8 +67,8 @@ StatusCode AugmentClustersFCCee::initialize()
   }
 
   // initialise the list of metadata for the clusters
-  // append to the metadata of the input clusters
-  std::vector<std::string> showerShapeDecorations = m_inShapeParameterHandle.get();
+  // append to the metadata of the input clusters (if any)
+  std::vector<std::string> showerShapeDecorations = m_inShapeParameterHandle.get({});
   for (size_t k = 0; k < m_detectorNames.size(); k++)
   {
     const char *detector = m_detectorNames[k].c_str();
@@ -91,8 +91,6 @@ StatusCode AugmentClustersFCCee::finalize()
 
 StatusCode AugmentClustersFCCee::execute([[maybe_unused]] const EventContext &evtCtx) const
 {
-
-
   // get the input collection with clusters
   const edm4hep::ClusterCollection *inClusters = m_inClusters.get();
 

--- a/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.h
+++ b/RecFCCeeCalorimeter/src/components/AugmentClustersFCCee.h
@@ -67,12 +67,12 @@ private:
       this, "systemNames", {"EMB"}, "Names of the detectors, corresponding to systemIDs"};
   /// Numbers of layers of the detectors
   Gaudi::Property<std::vector<size_t>> m_numLayers{
-      this, "numLayers", {12}, "Numbers of layers of the systems"};
+      this, "numLayers", {11}, "Numbers of layers of the systems"};
   /// Weights for each detector layer for theta position log-weighting
   Gaudi::Property<std::vector<std::vector<double>>> m_thetaRecalcLayerWeights{
       this,
       "thetaRecalcWeights",
-      {{-1, 3.0, 3.0, 3.0, 4.25, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0}},
+      {{-1, 3.0, 3.0, 3.0, 4.25, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0}},
       "Weights for each detector layer for theta position log-weighting. If negative use linear weight."};
   /// Name of the detector readouts, corresponding to system IDs in m_systemIDs
   Gaudi::Property<std::vector<std::string>> m_readoutNames{

--- a/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.cpp
+++ b/RecFCCeeCalorimeter/src/components/CalibrateCaloClusters.cpp
@@ -97,7 +97,7 @@ StatusCode CalibrateCaloClusters::initialize()
   }
 
   // read from the metadata the names of the shape parameters in the input clusters and append the total raw energy to the output
-  std::vector<std::string> shapeParameters = m_inShapeParameterHandle.get();
+  std::vector<std::string> shapeParameters = m_inShapeParameterHandle.get({});
   shapeParameters.push_back("rawE");
   m_outShapeParameterHandle.put(shapeParameters);
 
@@ -241,7 +241,10 @@ StatusCode CalibrateCaloClusters::readCalibrationFile(const std::string &calibra
   debug() << "Input Node Name/Shape (" << m_input_names.size() << "):" << endmsg;
   for (std::size_t i = 0; i < m_ortSession->GetInputCount(); i++)
   {
-    m_input_names.insert(m_input_names.end(), m_ortSession->GetInputNames().begin(), m_ortSession->GetInputNames().end());
+    // for old ONNX runtime version
+    // m_input_names.emplace_back(m_ortSession->GetInputName(i, allocator));
+    // for new runtime version
+    m_input_names.emplace_back(m_ortSession->GetInputNameAllocated(i, allocator).get());
     m_input_shapes = m_ortSession->GetInputTypeInfo(i).GetTensorTypeAndShapeInfo().GetShape();
     debug() << "\t" << m_input_names.at(i) << " : ";
     for (std::size_t k = 0; k < m_input_shapes.size() - 1; k++)
@@ -263,7 +266,10 @@ StatusCode CalibrateCaloClusters::readCalibrationFile(const std::string &calibra
   debug() << "Output Node Name/Shape (" << m_output_names.size() << "):" << endmsg;
   for (std::size_t i = 0; i < m_ortSession->GetOutputCount(); i++)
   {
-    m_output_names.insert(m_output_names.end(), m_ortSession->GetOutputNames().begin(), m_ortSession->GetOutputNames().end());
+    // for old ONNX runtime version
+    // m_output_names.emplace_back(m_ortSession->GetOutputName(i, allocator));
+    // for new runtime version
+    m_output_names.emplace_back(m_ortSession->GetOutputNameAllocated(i, allocator).get());
     m_output_shapes = m_ortSession->GetOutputTypeInfo(i).GetTensorTypeAndShapeInfo().GetShape();
     debug() << "\t" << m_output_names.at(i) << " : ";
     for (std::size_t k = 0; k < m_output_shapes.size() - 1; k++)

--- a/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.cpp
+++ b/RecFCCeeCalorimeter/src/components/CreateCaloCellPositionsFCCee.cpp
@@ -35,7 +35,11 @@ StatusCode CreateCaloCellPositionsFCCee::initialize() {
   }
 
   // Copy over the CellIDEncoding string from the input collection to the output collection
-  m_positionedHitsCellIDEncoding.put(m_hitsCellIDEncoding.get());
+  std::string hitsEncoding = m_hitsCellIDEncoding.get("");
+  if (hitsEncoding == "") {
+    warning() << "Missing cellID encoding for input collection" << endmsg;
+  }
+  m_positionedHitsCellIDEncoding.put(hitsEncoding);
 
   return StatusCode::SUCCESS;
 }


### PR DESCRIPTION
A few changes needed to support the turbine endcap ECal geometry:

- add kEndcapTurbine to enumerated segmentation types, and add code for handling that segmentation (detectorSegmentations/FCCSWEndcapTurbine_k4geo.h)
- generalize the Segmentation pointer type in a few places
- use cellTheta rather than segmentation->theta(cell.getCellID()) in CaloTowerToolFCCee::CellsIntoTowers

Note that this request must be merged at the same time as my request for k4geo.